### PR TITLE
Update PySide6 to 6.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests~=2.32.0
-PySide6~=6.6.1
+PySide6~=6.8.1
 tmdbv3api~=1.9.0
 beautifulsoup4~=4.12.3


### PR DESCRIPTION
When install PySide6 6.6.1 is not available for download. 6.8.1 installs and the app seems to run.